### PR TITLE
btaudio: aidl: Support offloading all LDAC qualities

### DIFF
--- a/bluetooth/audio/utils/aidl_session/BluetoothAudioCodecs.cpp
+++ b/bluetooth/audio/utils/aidl_session/BluetoothAudioCodecs.cpp
@@ -67,7 +67,8 @@ static const AacCapabilities kDefaultOffloadAacCapability = {
 static const LdacCapabilities kDefaultOffloadLdacCapability = {
     .sampleRateHz = {44100, 48000, 88200, 96000},
     .channelMode = {LdacChannelMode::DUAL, LdacChannelMode::STEREO},
-    .qualityIndex = {LdacQualityIndex::HIGH},
+    .qualityIndex = {LdacQualityIndex::HIGH, LdacQualityIndex::MID,
+                     LdacQualityIndex::LOW, LdacQualityIndex::ABR},
     .bitsPerSample = {16, 24, 32}};
 
 static const AptxCapabilities kDefaultOffloadAptxCapability = {


### PR DESCRIPTION
Atleast qcom BT stack supports hw offload of all
LDAC quality configurations (low, medium, high
and adaptive). Without this, it reports invalid
codec configuration and breaks the audio session.

10-21 12:24:25.649   880   903 W BTAudioCodecsAidl: IsOffloadLdacConfigurationValid: Unsupported CodecSpecific=CodecSpecific{ldacConfig: LdacConfiguration{sampleRateHz: 96000, channelMode: STEREO, qualityIndex: ABR, bitsPerSample: 32}}
10-21 12:24:25.649   880   903 W BTAudioProviderA2dpHW: startSession - Invalid Audio Configuration=AudioConfiguration{a2dpConfig: CodecConfiguration{codecType: LDAC, encodedAudioBitrate: 0, peerMtu: 666, isScmstEnabled: false, config: CodecSpecific{ldacConfig: LdacConfiguration{sampleRateHz: 96000, channelMode: STEREO, qualityIndex: ABR, bitsPerSample: 32}}}}
10-21 12:24:25.649 21520 21549 E bt_stack: [ERROR:client_interface.cc(391)] StartSession: BluetoothAudioHal Error: Status(-3, EX_ILLEGAL_ARGUMENT): '', audioConfig=AudioConfiguration{a2dpConfig: CodecConfiguration{codecType: LDAC, encodedAudioBitrate: 0, peerMtu: 666, isScmstEnabled: false, config: CodecSpecific{ldacConfig: LdacConfiguration{sampleRateHz: 96000, channelMode: STEREO, qualityIndex: ABR, bitsPerSample: 32}}}}

Change-Id: I50f0aee3af70b15dbc73a4e4570353b0adcdfa27