### PR TITLE
keymasterV4_0: Tags support for FBE wrapped key.

### DIFF
--- a/keymaster/4.0/support/include/keymasterV4_0/keymaster_tags.h
+++ b/keymaster/4.0/support/include/keymasterV4_0/keymaster_tags.h
@@ -73,6 +73,9 @@ namespace V4_0 {
 static const int32_t KM_TAG_DIGEST_OLD = static_cast<int32_t>(TagType::ENUM) | 5;
 static const int32_t KM_TAG_PADDING_OLD = static_cast<int32_t>(TagType::ENUM) | 7;
 
+static const int32_t KM_TAG_FBE_ICE = static_cast<int32_t>(TagType::BOOL) | 16201;
+static const int32_t KM_TAG_KEY_TYPE = static_cast<int32_t>(TagType::UINT) | 16202;
+
 constexpr TagType typeFromTag(Tag tag) {
     return static_cast<TagType>(static_cast<uint32_t>(tag) & static_cast<uint32_t>(0xf0000000));
 }


### PR DESCRIPTION
Define two new tags for FBE Key Management.
FBE_ICE: This is a boolean which specifies if new key management is used.
KEY_TYPE: Specifies if it is a DE_USER or a CE_USER key.

CRs-Fixed: 2288316

Change-Id: Id9468d1fab0b0517a0a96734cdfe5612855fd2d9